### PR TITLE
Allow building with GHC 9.10

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        ghc: ["9.4", "9.6", "9.8"]
+        ghc: ["9.4", "9.6", "9.8", "9.10"]
       fail-fast: false
 
     steps:
@@ -27,7 +27,7 @@ jobs:
         key: "${{ runner.os }}-${{ matrix.ghc }}-v9-${{ hashFiles('stylish-haskell.cabal') }}"
 
     - name: Build
-      run: cabal build 
+      run: cabal build
       id: build
 
     - name: Test

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        ghc: ["9.4", "9.6", "9.8", "9.10"]
+        ghc: ["9.6", "9.8", "9.10"]
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       name: Setup Haskell Cabal
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       id: get_version
       run: 'echo ::set-output name=version::${GITHUB_REF#refs/tags/}'
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: artifacts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        stack: ["2.1.3"]
-        ghc: ["8.8.3"]
+        stack: ["2.15.7"]
 
     steps:
     - name: Get the version
@@ -19,17 +18,18 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       name: Setup Haskell Stack
       with:
-        ghc-version: ${{ matrix.ghc }}
+        enable-stack: true
         stack-version: ${{ matrix.stack }}
+        stack-no-global: true
 
     - uses: actions/cache@v2
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: "${{ runner.os }}-${{ matrix.ghc }}-v9-${{ hashFiles('stylish-haskell.cabal', 'stack.yaml', 'stack.yaml.lock') }}"
+        key: "${{ runner.os }}-v9-${{ hashFiles('stylish-haskell.cabal', 'stack.yaml', 'stack.yaml.lock') }}"
 
     - name: Add ~/.local/bin to PATH
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ COMPRESS_BIN_DEPS=$(UPX_BINARY)
 COMPRESS_BIN=upx
 endif
 
-STACK=stack --system-ghc
+STACK=stack
 
 # Default target.
 .PHONY: build

--- a/lib/Language/Haskell/Stylish/GHC.hs
+++ b/lib/Language/Haskell/Stylish/GHC.hs
@@ -69,7 +69,7 @@ dropBeforeAndAfter :: Located a -> [RealLocated b] -> [RealLocated b]
 dropBeforeAndAfter loc = dropBeforeLocated (Just loc) . dropAfterLocated (Just loc)
 
 baseDynFlags :: GHC.DynFlags
-baseDynFlags = defaultDynFlags GHCEx.fakeSettings 
+baseDynFlags = defaultDynFlags GHCEx.fakeSettings
 
 getConDecls :: GHC.HsDataDefn GHC.GhcPs -> [GHC.LConDecl GHC.GhcPs]
 getConDecls d@GHC.HsDataDefn {} = case GHC.dd_cons d of
@@ -80,7 +80,6 @@ showOutputable :: GHC.Outputable a => a -> String
 showOutputable = GHC.showPpr baseDynFlags
 
 epAnnComments :: GHC.EpAnn a -> [GHC.LEpaComment]
-epAnnComments GHC.EpAnnNotUsed = []
 epAnnComments GHC.EpAnn {..}   = priorAndFollowing comments
 
 deepAnnComments :: (Data a, Typeable a) => a -> [GHC.LEpaComment]

--- a/lib/Language/Haskell/Stylish/Ordering.hs
+++ b/lib/Language/Haskell/Stylish/Ordering.hs
@@ -45,12 +45,12 @@ compareLIE = comparing $ ieKey . unLoc
     -- constructors first, followed by functions, and then operators.
     ieKey :: IE GhcPs -> (Int, String)
     ieKey = \case
-        IEVar _ n            -> nameKey n
-        IEThingAbs _ n       -> nameKey n
-        IEThingAll _ n       -> nameKey n
-        IEThingWith _ n _ _  -> nameKey n
-        IEModuleContents _ n -> nameKey n
-        _                    -> (2, "")
+        IEVar _ n  _          -> nameKey n
+        IEThingAbs _ n _      -> nameKey n
+        IEThingAll _ n  _     -> nameKey n
+        IEThingWith _ n _ _ _ -> nameKey n
+        IEModuleContents _ n  -> nameKey n
+        _                     -> (2, "")
 
 
 --------------------------------------------------------------------------------

--- a/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
+++ b/lib/Language/Haskell/Stylish/Step/ModuleHeader.hs
@@ -83,7 +83,7 @@ printModuleHeader maxCols conf ls lmodul =
 
         keywordLine kw = listToMaybe $ do
             GHC.EpAnn {..} <- pure $ GHC.hsmodAnn $ GHC.hsmodExt modul
-            GHC.AddEpAnn kw' (GHC.EpaSpan s _) <- GHC.am_main anns
+            GHC.AddEpAnn kw' (GHC.EpaSpan (GHC.RealSrcSpan s _)) <- GHC.am_main anns
             guard $ kw == kw'
             pure $ GHC.srcSpanEndLine s
 
@@ -104,7 +104,7 @@ printModuleHeader maxCols conf ls lmodul =
             Just lexports -> Just $ doSort $ commentGroups
                 (GHC.srcSpanToRealSrcSpan . GHC.getLocA)
                 (GHC.unLoc lexports)
-                (epAnnComments . GHC.ann $ GHC.getLoc lexports)
+                (epAnnComments $ GHC.getLoc lexports)
 
         printedModuleHeader = runPrinter_
             (PrinterConfig maxCols)

--- a/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
+++ b/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
@@ -12,7 +12,7 @@ module Language.Haskell.Stylish.Step.SimpleAlign
 --------------------------------------------------------------------------------
 import           Data.Either                     (partitionEithers)
 import           Data.Foldable                   (toList)
-import           Data.List                       (foldl', foldl1', sortOn)
+import           Data.List                       (foldl1', sortOn)
 import           Data.Maybe                      (fromMaybe)
 import qualified GHC.Hs                          as Hs
 import qualified GHC.Parser.Annotation           as GHC
@@ -160,9 +160,9 @@ multiWayIfToAlignable _conf _ = []
 
 --------------------------------------------------------------------------------
 grhsToAlignable
-    :: GHC.GenLocated (GHC.SrcSpanAnn' a) (Hs.GRHS Hs.GhcPs (Hs.LHsExpr Hs.GhcPs))
+    :: GHC.GenLocated (GHC.EpAnnCO) (Hs.GRHS Hs.GhcPs (Hs.LHsExpr Hs.GhcPs))
     -> Maybe (Alignable GHC.RealSrcSpan)
-grhsToAlignable (GHC.L (GHC.SrcSpanAnn _ grhsloc) (Hs.GRHS _ guards@(_ : _) body)) = do
+grhsToAlignable (GHC.L (GHC.EpAnn (GHC.EpaSpan grhsloc) _ _ ) (Hs.GRHS _ guards@(_ : _) body)) = do
     let guardsLocs = map GHC.getLocA guards
         bodyLoc    = GHC.getLocA $ body
         left       = foldl1' GHC.combineSrcSpans guardsLocs

--- a/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
+++ b/lib/Language/Haskell/Stylish/Step/SimpleAlign.hs
@@ -13,6 +13,7 @@ module Language.Haskell.Stylish.Step.SimpleAlign
 import           Data.Either                     (partitionEithers)
 import           Data.Foldable                   (toList)
 import           Data.List                       (foldl1', sortOn)
+import qualified Data.List                       as List
 import           Data.Maybe                      (fromMaybe)
 import qualified GHC.Hs                          as Hs
 import qualified GHC.Parser.Annotation           as GHC
@@ -117,7 +118,7 @@ matchToAlignable (GHC.L matchLoc m@(Hs.Match _ Hs.CaseAlt pats@(_ : _) grhss)) =
       pat        = last patsLocs
       guards     = getGuards m
       guardsLocs = map GHC.getLocA guards
-      left       = foldl' GHC.combineSrcSpans pat guardsLocs
+      left       = List.foldl' GHC.combineSrcSpans pat guardsLocs
   body     <- rhsBody grhss
   matchPos <- GHC.srcSpanToRealSrcSpan $ GHC.locA matchLoc
   leftPos  <- GHC.srcSpanToRealSrcSpan left

--- a/lib/Language/Haskell/Stylish/Step/Squash.hs
+++ b/lib/Language/Haskell/Stylish/Step/Squash.hs
@@ -45,11 +45,10 @@ squashFieldDecl _ = mempty
 
 
 --------------------------------------------------------------------------------
-fieldDeclSeparator :: GHC.EpAnn [GHC.AddEpAnn]-> Maybe GHC.RealSrcSpan
-fieldDeclSeparator GHC.EpAnn {..} = listToMaybe $ do
-    GHC.AddEpAnn GHC.AnnDcolon (GHC.EpaSpan s _) <- anns
+fieldDeclSeparator :: [GHC.AddEpAnn]-> Maybe GHC.RealSrcSpan
+fieldDeclSeparator anns = listToMaybe $ do
+    GHC.AddEpAnn GHC.AnnDcolon (GHC.EpaSpan (GHC.RealSrcSpan s _)) <- anns
     pure s
-fieldDeclSeparator _ = Nothing
 
 
 --------------------------------------------------------------------------------
@@ -76,7 +75,7 @@ squashMatch lmatch = case GHC.m_grhss match of
 --------------------------------------------------------------------------------
 matchSeparator :: GHC.EpAnn GHC.GrhsAnn -> Maybe GHC.RealSrcSpan
 matchSeparator GHC.EpAnn {..}
-    | GHC.AddEpAnn _ (GHC.EpaSpan s _) <- GHC.ga_sep anns = Just s
+    | GHC.AddEpAnn _ (GHC.EpaSpan (GHC.RealSrcSpan s _)) <- GHC.ga_sep anns = Just s
 matchSeparator _ = Nothing
 
 

--- a/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
+++ b/lib/Language/Haskell/Stylish/Step/UnicodeSyntax.hs
@@ -20,19 +20,20 @@ import           Language.Haskell.Stylish.Util                 (everything)
 --------------------------------------------------------------------------------
 hsTyReplacements :: GHC.HsType GHC.GhcPs -> Editor.Edits
 hsTyReplacements (GHC.HsFunTy _ arr _ _)
-    | GHC.HsUnrestrictedArrow (GHC.L (GHC.TokenLoc epaLoc) GHC.HsNormalTok) <- arr=
+    | GHC.HsUnrestrictedArrow (GHC.EpUniTok epaLoc GHC.NormalSyntax) <- arr =
         Editor.replaceRealSrcSpan (GHC.epaLocationRealSrcSpan epaLoc) "→"
 hsTyReplacements (GHC.HsQualTy _ ctx _)
-    | Just arrow <- GHC.ac_darrow . GHC.anns . GHC.ann $ GHC.getLoc ctx
-    , (GHC.NormalSyntax, GHC.EpaSpan loc _) <- arrow =
+    | Just arrow <- GHC.ac_darrow . GHC.anns $ GHC.getLoc ctx
+    , (GHC.NormalSyntax, GHC.EpaSpan (GHC.RealSrcSpan loc _)) <- arrow =
         Editor.replaceRealSrcSpan loc "⇒"
 hsTyReplacements _ = mempty
+
 
 --------------------------------------------------------------------------------
 hsSigReplacements :: GHC.Sig GHC.GhcPs -> Editor.Edits
 hsSigReplacements (GHC.TypeSig ann _ _)
-    | GHC.AddEpAnn GHC.AnnDcolon epaLoc <- GHC.asDcolon $ GHC.anns ann
-    , GHC.EpaSpan loc _ <- epaLoc =
+    | GHC.AddEpAnn GHC.AnnDcolon epaLoc <- GHC.asDcolon ann
+    , GHC.EpaSpan (GHC.RealSrcSpan loc _) <- epaLoc =
         Editor.replaceRealSrcSpan loc "∷"
 hsSigReplacements _ = mempty
 

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -59,17 +59,17 @@ Common depends
   -- and we have a new enough GHC. Note that
   -- this will only work if the user's
   -- compiler is of the matching major version!
-  if !flag(ghc-lib) && impl(ghc >= 9.8) && impl(ghc < 9.9)
+  if !flag(ghc-lib) && impl(ghc >= 9.8) && impl(ghc < 9.11)
     Build-depends:
-      ghc >= 9.8 && < 9.9,
+      ghc >= 9.10 && < 9.11,
       ghc-boot,
       ghc-boot-th
   else
     Build-depends:
-      ghc-lib-parser >= 9.8 && < 9.11
+      ghc-lib-parser >= 9.10 && < 9.11
 
   Build-depends:
-    ghc-lib-parser-ex >= 9.8 && < 9.11
+    ghc-lib-parser-ex >= 9.10 && < 9.11
 
 Library
   Import:         depends

--- a/stylish-haskell.cabal
+++ b/stylish-haskell.cabal
@@ -19,9 +19,11 @@ Description:
     <https://github.com/haskell/stylish-haskell/blob/master/README.markdown>
 
 Extra-source-files:
-  CHANGELOG,
   README.markdown,
   data/stylish-haskell.yaml
+
+Extra-doc-files:
+  CHANGELOG
 
 Flag ghc-lib
   Default: True
@@ -38,9 +40,9 @@ Common depends
     base              >= 4.8    && < 5,
     bytestring        >= 0.9    && < 0.13,
     Cabal             >= 3.4    && < 4.0,
-    containers        >= 0.3    && < 0.7,
+    containers        >= 0.3    && < 0.8,
     directory         >= 1.2.3  && < 1.4,
-    filepath          >= 1.1    && < 1.5,
+    filepath          >= 1.1    && < 1.6,
     file-embed        >= 0.0.10 && < 0.1,
     mtl               >= 2.0    && < 2.4,
     regex-tdfa        >= 1.3    && < 1.4,
@@ -54,8 +56,8 @@ Common depends
       semigroups >= 0.18 && < 0.20
 
   -- Use GHC if the ghc-lib flag is not set
-  -- and we have a new enough GHC. Note that 
-  -- this will only work if the user's 
+  -- and we have a new enough GHC. Note that
+  -- this will only work if the user's
   -- compiler is of the matching major version!
   if !flag(ghc-lib) && impl(ghc >= 9.8) && impl(ghc < 9.9)
     Build-depends:
@@ -64,10 +66,10 @@ Common depends
       ghc-boot-th
   else
     Build-depends:
-      ghc-lib-parser >= 9.8 && < 9.9
+      ghc-lib-parser >= 9.8 && < 9.11
 
   Build-depends:
-    ghc-lib-parser-ex >= 9.8 && < 9.9
+    ghc-lib-parser-ex >= 9.8 && < 9.11
 
 Library
   Import:         depends


### PR DESCRIPTION
- bump all bounds reported by `cabal outdated`
- fix a warning reported by `cabal check`
- include ghc 9.10 in CI config